### PR TITLE
Create TCP Sniffer.py

### DIFF
--- a/Shayan/TCP Sniffer.py
+++ b/Shayan/TCP Sniffer.py
@@ -1,0 +1,13 @@
+# Shayan Javid
+# Dr. Bartlett
+# TCP-SYN Sniffer
+from scapy.all import *
+
+cnt = 0
+def packet_format(packet):
+    global cnt
+    cnt+=1
+    return "packet #{}: {} --> {}".format(cnt, packet[0][1].src, packet[0][1].dst)
+    
+    
+sniff (filter = "tcp[tcpflags] & 2 == 2 and tcp[tcpflags] & 16 == 0", prn=packet_format)


### PR DESCRIPTION
Here it prints out all the incoming and outgoing packets, and with scapy you can't set a direction to just receive the packets, but if I want to only save/print the incoming packets I can do that with a simple if statement (if packet.dst = computer's IP address -> save/print the packet). Now with the macOS I can't get the computer's IP address (for example mine) because of "Root privileges" to do this "if statement". So I'm not sure what route to take regarding this issue. 
I will upload my code for getting the local ip address shortly.